### PR TITLE
Add -Spacious mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ This doesn't modify the source file; it outputs the clean version to a new file.
 Edit-DTWBeautifyScript -SourcePath C:\temp\MyFile.ps1 -DestinationPath c:\temp\MyFile_AFTER.ps1
 ```
 
+### Run on single file in Spacious mode
+By default, Beautifier removes spaces between comma-separated values and between type and variable name.
+This behaviour can be controller using `-Spacious` flag.
+```
+Edit-DTWBeautifyScript C:\temp\MyFile.ps1 -Spacious
+```
+
 ### Run on multiple files in a directory structure
 Time for the pipeline.
 ```

--- a/src/DTW.PS.Beautifier.Main.psm1
+++ b/src/DTW.PS.Beautifier.Main.psm1
@@ -53,6 +53,9 @@ function Initialize-ProcessVariables {
     # indent text, value is overridden with param
     [string]$script:IndentText = ''
 
+    # determines whether to add a space between comma-separated values and between [type] and variable name
+    [string]$script:Spacious = $false
+
     # ouput clean script to standard output instead of source or destination path 
     [bool]$script:StandardOutput = $false
 
@@ -986,10 +989,13 @@ function Test-AddSpaceFollowingToken {
     if ($SourceTokens[$TokenIndex].Type -eq 'NewLine') { return $false }
     #endregion
 
-    #region Don't write space after type Type if followed by GroupStart, Number, String, Type or Variable (for example [int]$Age or [int]"5")
-    # don't write at space after, for example [int]
-    if ((($TokenIndex + 1) -lt $SourceTokens.Count) -and $SourceTokens[$TokenIndex].Type -eq 'Type' -and ('GroupStart','Number','String','Type','Variable') -contains $SourceTokens[$TokenIndex + 1].Type) { return $false }
-    #endregion
+
+    if (-not $Spacious) {
+      #region Don't write space after type Type if followed by GroupStart, Number, String, Type or Variable (for example [int]$Age or [int]"5")
+      # don't write at space after, for example [int]
+      if ((($TokenIndex + 1) -lt $SourceTokens.Count) -and $SourceTokens[$TokenIndex].Type -eq 'Type' -and ('GroupStart','Number','String','Type','Variable') -contains $SourceTokens[$TokenIndex + 1].Type) { return $false }
+      #endregion
+    }
 
     #region Don't write space if next token is StatementSeparator (;) or NewLine
     if (($TokenIndex + 1) -lt $SourceTokens.Count) {
@@ -1034,8 +1040,13 @@ function Test-AddSpaceFollowingToken {
     if ((($TokenIndex + 1) -lt $SourceTokens.Count) -and $SourceTokens[$TokenIndex].Type -eq 'Variable' -and $SourceTokens[$TokenIndex + 1].Type -eq 'Operator' -and $SourceTokens[$TokenIndex + 1].Content -eq '[') { return $false }
     #endregion
 
-    #region Don't add space after Operators: , !
-    if ($SourceTokens[$TokenIndex].Type -eq 'Operator' -and ($SourceTokens[$TokenIndex].Content -eq ',' -or $SourceTokens[$TokenIndex].Content -eq '!')) { return $false }
+    if (-not $Spacious) {
+      #region Don't add space after Operator: , (unless we're in Spacious mode)
+      if ($SourceTokens[$TokenIndex].Type -eq 'Operator' -and ($SourceTokens[$TokenIndex].Content -eq ',')) { return $false }
+    }
+
+    #region Don't add space after Operator: !
+    if ($SourceTokens[$TokenIndex].Type -eq 'Operator' -and $SourceTokens[$TokenIndex].Content -eq '!') { return $false }
     #endregion
 
     #region Don't add space if next Operator token is: , ++ ;
@@ -1127,6 +1138,9 @@ Path to the source PowerShell file
 .PARAMETER DestinationPath
 Path to write reformatted PowerShell.  If not specified rewrites file
 in place.
+.PARAMETER Spacious
+By default, Beautifier will prefer to remove spaces between comma-separated values and
+bewteen type and variable name (e.g. [string]$foo). Setting this flag flips this behaviour.
 .PARAMETER IndentType
 Type of indent to use: TwoSpaces, FourSpaces or Tabs
 .PARAMETER StandardOutput
@@ -1166,6 +1180,8 @@ function Edit-DTWBeautifyScript {
     [Parameter(Mandatory = $false,ValueFromPipeline = $false)]
     [ValidateSet("TwoSpaces","FourSpaces","Tabs")]
     [string]$IndentType = "TwoSpaces",
+    [Parameter(Mandatory = $false)]
+    [switch]$Spacious = $false,
     [Alias('StdOut')]
     [switch]$StandardOutput,
     [Parameter(Mandatory = $false,ValueFromPipeline = $false)]
@@ -1214,6 +1230,10 @@ function Edit-DTWBeautifyScript {
     }
     # set script level variable
     $script:IndentText = $IndentText
+    #endregion
+
+    #region Set script-level variable for Spacious param
+    $script:Spacious = $Spacious
     #endregion
 
     #region Set script-level variable StandardOutput

--- a/test/1_Input_Bad/SpaciousMode/CommaSeparated.ps1
+++ b/test/1_Input_Bad/SpaciousMode/CommaSeparated.ps1
@@ -1,0 +1,3 @@
+$StringArrayWithSpaces = @("1",     "2","3")
+$IntArrayWithSpaces = @( 1,             2,
+3)

--- a/test/1_Input_Bad/SpaciousMode/Types.ps1
+++ b/test/1_Input_Bad/SpaciousMode/Types.ps1
@@ -1,0 +1,5 @@
+[string]            $Hello = "Cześć"
+
+function Foo {
+    param([int]     $Value)
+}

--- a/test/3_Output_Correct/SpaciousMode/NotSpacious_CommaSeparated.ps1
+++ b/test/3_Output_Correct/SpaciousMode/NotSpacious_CommaSeparated.ps1
@@ -1,0 +1,3 @@
+$StringArrayWithSpaces = @( "1","2","3")
+$IntArrayWithSpaces = @( 1,2,
+  3)

--- a/test/3_Output_Correct/SpaciousMode/NotSpacious_Types.ps1
+++ b/test/3_Output_Correct/SpaciousMode/NotSpacious_Types.ps1
@@ -1,0 +1,5 @@
+[string]$Hello = "Cześć"
+
+function Foo {
+  param([int]$Value)
+}

--- a/test/3_Output_Correct/SpaciousMode/Spacious_CommaSeparated.ps1
+++ b/test/3_Output_Correct/SpaciousMode/Spacious_CommaSeparated.ps1
@@ -1,0 +1,3 @@
+$StringArrayWithSpaces = @( "1", "2", "3")
+$IntArrayWithSpaces = @( 1, 2,
+  3)

--- a/test/3_Output_Correct/SpaciousMode/Spacious_Types.ps1
+++ b/test/3_Output_Correct/SpaciousMode/Spacious_Types.ps1
@@ -1,0 +1,5 @@
+[string] $Hello = "Cześć"
+
+function Foo {
+  param([int] $Value)
+}


### PR DESCRIPTION
Introduces `-Spacious` mode to optionally:
* add spaces between comma-separated values, like `$arr = @( 1, 2, 3)`
* add space between type and variable name, like `[int] $foo`

This is of course up to personal taste, therefore the flag is optional and tests are making sure that the normal mode works.

A better solution would be to have some kind of config file for this type of changes, but it looks like it would require refactors in many places.