### PR TITLE
Extra parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ SYNOPSIS
 
 SYNTAX
     Edit-DTWBeautifyScript [-SourcePath] <String> [[-DestinationPath] <String>] [[-IndentType] <String>]
-    [-StandardOutput] [[-NewLine] <String>] [<CommonParameters>]
+    [-SpaceAfterComma] [-StandardOutput] [[-NewLine] <String>]
     [<CommonParameters>]
 
 ...more text...

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ SYNOPSIS
 
 SYNTAX
     Edit-DTWBeautifyScript [-SourcePath] <String> [[-DestinationPath] <String>] [[-IndentType] <String>]
-    [-SpaceAfterComma] [-StandardOutput] [[-NewLine] <String>]
+    [-SpaceAfterComma] [[-AddSpaceAfter] <ScriptBlock>] [-StandardOutput] [[-NewLine] <String>]
     [<CommonParameters>]
 
 ...more text...

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ SYNOPSIS
 
 SYNTAX
     Edit-DTWBeautifyScript [-SourcePath] <String> [[-DestinationPath] <String>] [[-IndentType] <String>]
-    [-SpaceAfterComma] [[-AddSpaceAfter] <ScriptBlock>] [-StandardOutput] [[-NewLine] <String>]
+    [-SpaceAfterComma] [-TreatAllgroupsEqual] [[-AddSpaceAfter] <ScriptBlock>] [-StandardOutput] [[-NewLine] <String>]
     [<CommonParameters>]
 
 ...more text...

--- a/src/DTW.PS.Beautifier.Main.psm1
+++ b/src/DTW.PS.Beautifier.Main.psm1
@@ -53,6 +53,9 @@ function Initialize-ProcessVariables {
     # indent text, value is overridden with param
     [string]$script:IndentText = ''
 
+    # space after comma, value is overridden with param
+    [bool]$script:SpaceAfterComma = $false
+
     # ouput clean script to standard output instead of source or destination path
     [bool]$script:StandardOutput = $false
 
@@ -1058,8 +1061,12 @@ function Test-AddSpaceFollowingToken {
     if ((($TokenIndex + 1) -lt $SourceTokens.Count) -and $SourceTokens[$TokenIndex].Type -eq 'Variable' -and $SourceTokens[$TokenIndex + 1].Type -eq 'Operator' -and $SourceTokens[$TokenIndex + 1].Content -eq '[') { return $false }
     #endregion
 
-    #region Don't add space after Operators: , !
-    if ($SourceTokens[$TokenIndex].Type -eq 'Operator' -and ($SourceTokens[$TokenIndex].Content -eq ',' -or $SourceTokens[$TokenIndex].Content -eq '!')) { return $false }
+    #region Space after Operators: ,
+    if ($SourceTokens[$TokenIndex].Type -eq 'Operator' -and ($SourceTokens[$TokenIndex].Content -eq ',')) { return $script:SpaceAfterComma }
+    #endregion
+
+    #region Don't add space after Operators: !
+    if ($SourceTokens[$TokenIndex].Type -eq 'Operator' -and ($SourceTokens[$TokenIndex].Content -eq '!')) { return $false }
     #endregion
 
     #region Don't add space if next Operator token is: , ++ ; (except if it's after return keyword)
@@ -1154,6 +1161,8 @@ Path to write reformatted PowerShell.  If not specified rewrites file
 in place.
 .PARAMETER IndentType
 Type of indent to use: TwoSpaces, FourSpaces or Tabs
+.PARAMETER SpaceAfterComma
+Whether to add a space after a comma (,). Default = $false.
 .PARAMETER StandardOutput
 If specified, cleaned script is only written to stdout, not any file, and
 any errors will be written to stderror using concise format (not Write-Error).
@@ -1191,6 +1200,8 @@ function Edit-DTWBeautifyScript {
     [Parameter(Mandatory = $false,ValueFromPipeline = $false)]
     [ValidateSet("TwoSpaces","FourSpaces","Tabs")]
     [string]$IndentType = "TwoSpaces",
+    [switch]
+    $SpaceAfterComma,
     [Alias('StdOut')]
     [switch]$StandardOutput,
     [Parameter(Mandatory = $false,ValueFromPipeline = $false)]
@@ -1240,6 +1251,9 @@ function Edit-DTWBeautifyScript {
     # set script level variable
     $script:IndentText = $IndentText
     #endregion
+
+    #region Other parameters
+    $script:SpaceAfterComma = $SpaceAfterComma
 
     #region Set script-level variable StandardOutput
     $script:StandardOutput = $StandardOutput


### PR DESCRIPTION
We use a slightly different style for formatting PS code but still would like to use this formatter so here's a bunch of changes which gets it to the style we use. Summary:
- adding spaces after each comma (pretty common I think)
- treating all groups the same for consistency (so both `@()` and `@{}` for instance are formatted the same instead of the latter having spaces but not the former)
- custom function for spacing simply because we're so used to having e.g. `$x | %{...}` instead of  `$x | % {}`
All of these are optional so existing users shouldn't be affected, I think.

For reference, example of how we use this now:
```
$psBeautify = Get-Module PowerShell-Beautifier;
# Super-common aliases shouldn't be replaced
 @('?', '%', 'rm', 'cd') | %{$psBeautify.PrivateData.ValidCommandNames.Remove($_)}

# All of this is just so that Object gets turned into object, just like e.g. String is turned into string
$accel = [PowerShell].Assembly.GetType("System.Management.Automation.TypeAccelerators")
$accel::Add("object",[System.Object])
$builtinField = $accel.GetField("builtinTypeAccelerators", [System.Reflection.BindingFlags]"Static,NonPublic")
$builtinField.SetValue($builtinField, $accel::Get)

# Don't add space after ? and %
$customSpacing = {
  param($SourceTokens, $TokenIndex)
  if ($SourceTokens[$TokenIndex].Type -eq 'Command' -and (@('?', '%') -eq $SourceTokens[$TokenIndex].Content)) {
    return $false
  }
  $null
}

# Invoke beautifier with our options
Edit-DTWBeautifyScript -NewLine LF -SpaceAfterComma -TreatAllGroupsEqual -AddSpaceAfter $customSpacing $args
```